### PR TITLE
refactor seeding files

### DIFF
--- a/app/views/galleries/show.html.erb
+++ b/app/views/galleries/show.html.erb
@@ -6,7 +6,7 @@
 </p>
 <p>
   <strong>Curator:</strong>
-  <%= @gallery.user.username || "Uncurated" %>
+  <%= @gallery.author.username || "Uncurated" %>
 </p>
 
 <!-- *****************************************************************************************************************

--- a/db/seed_comments_nested.rb
+++ b/db/seed_comments_nested.rb
@@ -1,0 +1,34 @@
+# Given the existing projects,
+
+users = User.all.to_a.each
+Project.all.each do |project|
+  puts "\tCreating comments for project id: #{project.id}..."
+  current_comments = []
+  def next_user(users)
+    begin
+      users.next
+    rescue StopIteration => ex
+      users.rewind
+      next_user(users)
+    end
+  end
+
+  #  multiple levels of nested comments
+  (1..2).each do
+    current_comments.append(FactoryGirl.create(:comment, author: next_user(users), project: project, parent: nil))
+  end
+  tmp = current_comments
+  current_comments = []
+  tmp.each do |comment|
+    (1..3).each do
+      current_comments.append(FactoryGirl.create(:comment, author: next_user(users), project: project, parent: comment))
+    end
+  end
+  tmp = current_comments
+  current_comments = []
+  tmp.each do |comment|
+    (1..2).each do
+      current_comments.append(FactoryGirl.create(:comment, author: next_user(users), project: project, parent: comment))
+    end
+  end
+end

--- a/db/seed_comments_nested.rb
+++ b/db/seed_comments_nested.rb
@@ -14,20 +14,20 @@ Project.all.each do |project|
   end
 
   #  multiple levels of nested comments
-  (1..2).each do
+  2.times do
     current_comments.append(FactoryGirl.create(:comment, author: next_user(users), project: project, parent: nil))
   end
   tmp = current_comments
   current_comments = []
   tmp.each do |comment|
-    (1..3).each do
+    3.times do
       current_comments.append(FactoryGirl.create(:comment, author: next_user(users), project: project, parent: comment))
     end
   end
   tmp = current_comments
   current_comments = []
   tmp.each do |comment|
-    (1..2).each do
+    2.times do
       current_comments.append(FactoryGirl.create(:comment, author: next_user(users), project: project, parent: comment))
     end
   end

--- a/db/seed_galleries.rb
+++ b/db/seed_galleries.rb
@@ -1,0 +1,14 @@
+# Galleries
+users = User.all.to_a.each
+5.times do
+  puts "\tCreating gallery..."
+  def next_user(user_list)
+    begin
+      user_list.next
+    rescue StopIteration => ex
+      user_list.rewind
+      next_user(user_list)
+    end
+  end
+  g = FactoryGirl.create(:gallery, author: next_user(users))
+end

--- a/db/seed_galleries.rb
+++ b/db/seed_galleries.rb
@@ -10,5 +10,5 @@ users = User.all.to_a.each
       next_user(user_list)
     end
   end
-  g = FactoryGirl.create(:gallery_with_projects, author: next_user(users))
+  g = FactoryGirl.create(:gallery, projects_count: 5, author: next_user(users))
 end

--- a/db/seed_galleries.rb
+++ b/db/seed_galleries.rb
@@ -10,5 +10,5 @@ users = User.all.to_a.each
       next_user(user_list)
     end
   end
-  g = FactoryGirl.create(:gallery, author: next_user(users))
+  g = FactoryGirl.create(:gallery_with_projects, author: next_user(users))
 end

--- a/db/seed_users_and_projects.rb
+++ b/db/seed_users_and_projects.rb
@@ -1,0 +1,13 @@
+# Create a super user and some test users, then create projects with those users.
+
+User.create(username: 'superuser', email: 'super_user@example.com', password: 'helloworld', password_confirmation: 'helloworld', super_admin: true)
+puts 'Starting seeding.'
+(1..30).each do
+  u = FactoryGirl.create(:user)
+  puts "\tCreating user..."
+  (1..10).each do
+    p = FactoryGirl.create(:project, author: u)
+  end
+end
+
+puts "\t Created #{Project.count} projects."

--- a/db/seed_users_and_projects.rb
+++ b/db/seed_users_and_projects.rb
@@ -2,12 +2,10 @@
 
 User.create(username: 'superuser', email: 'super_user@example.com', password: 'helloworld', password_confirmation: 'helloworld', super_admin: true)
 puts 'Starting seeding.'
-(1..30).each do
+30.times do
   u = FactoryGirl.create(:user)
   puts "\tCreating user..."
-  (1..10).each do
+  10.times do
     p = FactoryGirl.create(:project, author: u)
   end
 end
-
-puts "\t Created #{Project.count} projects."

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -6,47 +6,13 @@
 #   cities = City.create([{ name: 'Chicago' }, { name: 'Copenhagen' }])
 #   Mayor.create(name: 'Emanuel', city: cities.first)
 
-User.create(username: 'superuser', email: 'super_user@example.com', password: 'helloworld', password_confirmation: 'helloworld', super_admin: true)
-projects = []
-puts 'Starting seeding.'
-(1..30).each do
-  u = FactoryGirl.create(:user)
-  puts "\tCreating user..."
-  (1..10).each do
-    p = FactoryGirl.create(:project, author: u)
-  end
-end
+# Clean out old test data
+puts "Cleaning out old data."
+User.delete_all
+Project.delete_all
+Comment.delete_all
+Gallery.delete_all
 
-
-users = User.all.to_a.each
-puts "\t Created #{Project.count} projects."
-Project.all.each do |project|
-  puts "\tCreating comments for project id: #{project.id}..."
-  current_comments = []
-  def next_user(users)
-    begin
-      users.next
-    rescue StopIteration => ex
-      users.rewind
-      next_user(users)
-    end
-  end
-
-  (1..2).each do
-    current_comments.append(FactoryGirl.create(:comment, author: next_user(users), project: project, parent: nil))
-  end
-  tmp = current_comments
-  current_comments = []
-  tmp.each do |comment|
-    (1..3).each do
-      current_comments.append(FactoryGirl.create(:comment, author: next_user(users), project: project, parent: comment))
-    end
-  end
-  tmp = current_comments
-  current_comments = []
-  tmp.each do |comment|
-    (1..2).each do
-      current_comments.append(FactoryGirl.create(:comment, author: next_user(users), project: project, parent: comment))
-    end
-  end
-end
+Dir[Rails.root.join("db/seed_user*.rb")].each {|f| require f}
+Dir[Rails.root.join("db/seed_comment*.rb")].each {|f| require f}
+Dir[Rails.root.join("db/seed_galleries*.rb")].each {|f| require f}

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -16,3 +16,8 @@ Gallery.delete_all
 Dir[Rails.root.join("db/seed_user*.rb")].each {|f| require f}
 Dir[Rails.root.join("db/seed_comment*.rb")].each {|f| require f}
 Dir[Rails.root.join("db/seed_galleries*.rb")].each {|f| require f}
+
+puts "\n*** Summary ***"
+puts "Created #{Project.count} projects."
+puts "Created #{Comment.count} total comments."
+puts "Created #{Gallery.count} galleries."

--- a/spec/factories/galleries.rb
+++ b/spec/factories/galleries.rb
@@ -3,8 +3,19 @@
 FactoryGirl.define do
   factory :gallery do
     title { Faker::Lorem.sentence(2, false, 4) }
-    after(:build) do
+    author
 
+    factory :gallery_with_projects do
+
+      # see https://github.com/thoughtbot/factory_girl/blob/v4.4.0/GETTING_STARTED.md#transient-attributes
+      # for what this is doing. I want 5 projects to be created with every gallery
+      ignore do
+        projects_count 5
+      end
+
+      after(:create) do |gallery, evaluator|
+        gallery.projects = FactoryGirl.create_list(:project, evaluator.projects_count)
+      end
     end
   end
 end

--- a/spec/factories/galleries.rb
+++ b/spec/factories/galleries.rb
@@ -5,15 +5,12 @@ FactoryGirl.define do
     title { Faker::Lorem.sentence(2, false, 4) }
     author
 
-    factory :gallery_with_projects do
+    transient do
+      projects_count 0
+    end
 
-      # see https://github.com/thoughtbot/factory_girl/blob/v4.4.0/GETTING_STARTED.md#transient-attributes
-      # for what this is doing. I want 5 projects to be created with every gallery
-      ignore do
-        projects_count 5
-      end
-
-      after(:create) do |gallery, evaluator|
+    after(:build) do |gallery, evaluator|
+      if evaluator.projects_count > 0 && gallery.projects.empty?
         gallery.projects = FactoryGirl.create_list(:project, evaluator.projects_count)
       end
     end


### PR DESCRIPTION
In anticipation of future load testing where we will have to test thousands or hundreds of thousands of data items, I think it is useful to factor out the seeding for different models. It is also helpful when testing--for example I was working on adding the galleries seed data, but I didn't want to recreate the project/comments data each time I ran seeds.rb. Therefore I just commented out the other `require` lines in `seeds.rb` so I could just focus on galleries. 

We might have to change naming conventions over time, but I think this is a good start
